### PR TITLE
Multiple tunnels

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -8,23 +8,40 @@ var _ = require("lodash");
  * @param {Function} cb
  */
 module.exports.plugin = function (bs, tunnelRunner, cb) {
-
     var opts         = {};
     var options      = bs.options;
     var port         = bs.options.port;
     //var debug        = bs.debug;
 
-    if (_.isString(options.tunnel)) {
-        opts.subdomain = options.tunnel;
+    if (_.isArray(options.tunnel)) {
+        var urls = [];
+        options.tunnel.forEach(function (subdomain) {
+            var opts = {
+             subdomain: subdomain
+            };
+
+            tunnelRunner(port, opts, function (err, tunnel) {
+                if (err) {
+                    throw err;
+                }
+                urls.push(tunnel.url);
+                if (urls.length === options.tunnel.length) {
+                    cb(urls.join("\n"), true);
+                }
+            });
+
+        });
+    } else {
+        if (_.isString(options.tunnel)) { opts.subdomain = options.tunnel; }
+
+        tunnelRunner(port, opts, function (err, tunnel) {
+            if (err) {
+                throw err;
+            }
+            cb(tunnel.url, true);
+        });
     }
 
     //debug("Trying tunnel connection with: %s ", options.tunnel || "no subdomain specified");
-
-    tunnelRunner(port, opts, function (err, tunnel) {
-        if (err) {
-            throw err;
-        }
-        cb(tunnel.url, true);
-    });
 
 };

--- a/test/specs/e2e/e2e.server.tunnel.js
+++ b/test/specs/e2e/e2e.server.tunnel.js
@@ -82,6 +82,25 @@ describe("E2E server test with tunnel", function () {
             done();
         });
     });
+    it("can create multiple tunnel connections with an array of sub domains", function (done) {
+        tunnel.plugin({
+            options: {
+                urls: {},
+                tunnel: [
+                    "shane0987654321",
+                    "imran0987654321"
+                ],
+                port: _port
+            },
+            events: {}
+        }, require("localtunnel"), function (url, bool) {
+            assert.include(url, "shane0987654321");
+            assert.include(url, "imran0987654321");
+            assert.isTrue(bool);
+            done();
+        });
+    });
+
 });
 
 describe("Creating tunnels", function () {


### PR DESCRIPTION
This change adds support for multiple tunnel subdomains to be created whilst retaining current behaviour.

```js
browserSync({
  tunnel: [ 'subdomain1', 'subdomain2' ]
  ...
});
```